### PR TITLE
feat: allowing to pass required_fields

### DIFF
--- a/lib/mentor/ecto/json_schema.ex
+++ b/lib/mentor/ecto/json_schema.ex
@@ -63,6 +63,13 @@ defmodule Mentor.Ecto.JSONSchema do
         []
       end
 
+    required =
+      if function_exported?(ecto_schema, :__mentor_required_fields__, 0) do
+        ecto_schema.__mentor_required_fields__()
+      else
+        []
+      end
+
     properties =
       :fields
       |> ecto_schema.__schema__()
@@ -97,7 +104,14 @@ defmodule Mentor.Ecto.JSONSchema do
       end)
 
     properties = Map.merge(properties, associations)
-    required = properties |> Map.keys() |> Enum.sort()
+
+    required =
+      if required != [] do
+        required
+      else
+        properties |> Map.keys() |> Enum.sort()
+      end
+
     title = title_for(ecto_schema)
 
     associated_schemas =
@@ -136,7 +150,19 @@ defmodule Mentor.Ecto.JSONSchema do
         {field, for_type(type)}
       end
 
-    required = properties |> Map.keys() |> Enum.sort()
+    required =
+      if is_map_key(ecto_types, :__mentor_required_fields__) do
+        ecto_types[:__mentor_required_fields__]
+      else
+        []
+      end
+
+    required =
+      if required != [] do
+        required
+      else
+        properties |> Map.keys() |> Enum.sort()
+      end
 
     embedded_schemas =
       for {_field, {:parameterized, {Ecto.Embedded, %{related: related}}}} <-

--- a/lib/mentor/ecto/schema.ex
+++ b/lib/mentor/ecto/schema.ex
@@ -92,6 +92,33 @@ defmodule Mentor.Ecto.Schema do
   > ### Warning {: .warning}
   >
   > Defining timestamps aliases with the macro `timestamps/1` inside the schema itself, aren't supported, since i didn't discover how to get this data from on compile time to filter as ignored fields, sou you can either define these options as the attribute as said above, or pass the individual aliases names into the `ignored_fields` options.
+
+  ## Required fields
+
+  By default, all fields in the schema are considered required in the generated JSON Schema. If you want to specify only certain fields as required, you can use the `required_fields` option:
+
+      defmodule MyApp.Schema do
+        use Ecto.Schema
+        use Mentor.Ecto.Schema, required_fields: [:description]
+
+        import Ecto.Changeset
+
+        @primary_key false
+        embedded_schema do
+          field :name, :string
+          field :description, :string
+          field :metadata, :map
+        end
+
+        @impl true
+        def changeset(%__MODULE__{} = source, %{} = attrs) do
+          source
+          |> cast(attrs, [:name, :description, :metadata])
+          |> validate_required([:description])
+        end
+      end
+
+  In this example, only the `:description` field will be passed as required in the response_format for the llm.
   """
 
   @behaviour Mentor.Schema
@@ -105,6 +132,7 @@ defmodule Mentor.Ecto.Schema do
 
   defmacro __using__(opts \\ []) do
     ignored = opts[:ignored_fields] || []
+    required = opts[:required_fields] || []
 
     quote do
       @before_compile Mentor.Ecto.Schema
@@ -113,6 +141,9 @@ defmodule Mentor.Ecto.Schema do
 
       @doc false
       def __mentor_ignored_fields__, do: unquote(ignored)
+
+      @doc false
+      def __mentor_required_fields__, do: unquote(required)
     end
   end
 


### PR DESCRIPTION
## Problem

All the schema fields gets passed as `required` in the response_format schema by default. This by itself isn't an issue, but we might want to specify which of them are required.

## Solution

Allow to pass an option in `Mentor.Ecto.Schema` to specify which fields are required `required_fields`

## Rationale

The behaviour is similar to the already existing `ignored_fields`, so to me made sense to implement this way.
