### PR TITLE
feat: adding a function to adjust response schema for gemini

### DIFF
--- a/lib/mentor/llm/adapters/gemini.ex
+++ b/lib/mentor/llm/adapters/gemini.ex
@@ -128,14 +128,14 @@ defmodule Mentor.LLM.Adapters.Gemini do
         }
       end)
 
-    schema_without_additional_props = Map.delete(mentor.json_schema, :additionalProperties)
+    updated_schema = update_schema_for_gemini(mentor.json_schema, mentor.config)
 
     body = %{
       contents: contents,
       generationConfig: %{
         temperature: config[:temperature],
         response_mime_type: "application/json",
-        response_schema: schema_without_additional_props
+        response_schema: updated_schema
       }
     }
 
@@ -143,6 +143,15 @@ defmodule Mentor.LLM.Adapters.Gemini do
       Map.put(body, :system_instruction, system_instruction)
     else
       body
+    end
+  end
+
+  defp update_schema_for_gemini(schema, config) do
+    schema_without_additional_props = Map.delete(schema, :additionalProperties)
+
+    case Keyword.get(config, :required_fields) do
+      nil -> schema_without_additional_props
+      required_fields -> %{schema_without_additional_props | required: required_fields}
     end
   end
 


### PR DESCRIPTION
## Problem

Gemini expects optional fields not to be passed as `required` in the `response_schema`. Differently from OpenAI which expects all the schema fields to be passed.

## Solution

Update the response_schema before sending to Gemini, checking the `required_fields` from the adapter config.

## Rationale

Since this approach will vary depending on the provider, implemented a simple private method `update_schema_for_gemini` that updates the schema when building the request body.
